### PR TITLE
Fix polyphonic demo

### DIFF
--- a/mozziscout/KeyBuffer.cpp
+++ b/mozziscout/KeyBuffer.cpp
@@ -2,7 +2,7 @@
 #include "KeyBuffer.h"
 
 #define CIRCULAR_BUFFER_DEBUG
-#include <CircularBuffer.h>
+#include <CircularBuffer.hpp>
 #include <Keypad.h>
 
 const byte ROWS = 4;

--- a/mozziscout/KeyBuffer.h
+++ b/mozziscout/KeyBuffer.h
@@ -1,5 +1,5 @@
 #define CIRCULAR_BUFFER_DEBUG
-#include <CircularBuffer.h>
+#include <CircularBuffer.hpp>
 #include <Keypad.h>
 
 #ifndef KeyBuffer_h

--- a/mozziscout_poly/mozziscout_poly.ino
+++ b/mozziscout_poly/mozziscout_poly.ino
@@ -11,7 +11,7 @@
 
 #include <MozziGuts.h>
 #include <Oscil.h> // oscillator template
-#include <tables/cos8192_int8.h>
+#include <tables/smoothsquare8192_int8.h>
 #include <mozzi_midi.h> // for mtof()
 #include <ADSR.h>
 #include <Keypad.h>
@@ -35,12 +35,12 @@ Keypad keys = Keypad(makeKeymap(key_indexes), rowPins, colPins, ROWS, COLS);
 #define NUM_VOICES 5
 #define CONTROL_RATE 64
 
-Oscil<COS8192_NUM_CELLS, AUDIO_RATE> myOscs[ NUM_VOICES ] = {
-  Oscil<COS8192_NUM_CELLS, AUDIO_RATE>(COS8192_DATA),
-  Oscil<COS8192_NUM_CELLS, AUDIO_RATE>(COS8192_DATA),
-  Oscil<COS8192_NUM_CELLS, AUDIO_RATE>(COS8192_DATA),
-  Oscil<COS8192_NUM_CELLS, AUDIO_RATE>(COS8192_DATA),
-  Oscil<COS8192_NUM_CELLS, AUDIO_RATE>(COS8192_DATA),
+Oscil<SMOOTHSQUARE8192_NUM_CELLS, AUDIO_RATE> myOscs[ NUM_VOICES ] = {
+  Oscil<SMOOTHSQUARE8192_NUM_CELLS, AUDIO_RATE>(SMOOTHSQUARE8192_DATA),
+  Oscil<SMOOTHSQUARE8192_NUM_CELLS, AUDIO_RATE>(SMOOTHSQUARE8192_DATA),
+  Oscil<SMOOTHSQUARE8192_NUM_CELLS, AUDIO_RATE>(SMOOTHSQUARE8192_DATA),
+  Oscil<SMOOTHSQUARE8192_NUM_CELLS, AUDIO_RATE>(SMOOTHSQUARE8192_DATA),
+  Oscil<SMOOTHSQUARE8192_NUM_CELLS, AUDIO_RATE>(SMOOTHSQUARE8192_DATA),
 };
 
 // volume control envelopes
@@ -64,7 +64,8 @@ void setup() {
 
   for ( int i = 0; i < NUM_VOICES; i++) {
     myEnvs[i].setADLevels(255, 255);
-    myEnvs[i].setTimes(100, 200, 750, 750); 
+//    myEnvs[i].setTimes(100, 200, 20000, 750); 
+    myEnvs[i].setTimes(20, 50, 20000, 50); 
   }
 
   startMozzi(); // start with default control rate of 64

--- a/mozziscout_poly/mozziscout_poly.ino
+++ b/mozziscout_poly/mozziscout_poly.ino
@@ -64,7 +64,6 @@ void setup() {
 
   for ( int i = 0; i < NUM_VOICES; i++) {
     myEnvs[i].setADLevels(255, 255);
-//    myEnvs[i].setTimes(100, 200, 20000, 750); 
     myEnvs[i].setTimes(20, 50, 20000, 50); 
   }
 


### PR DESCRIPTION
Fixed polyphonic demo so that keys don't get stuck on or off. 
Also changed the wave from cosine to square in order to make it louder, and be closer to the original Scout in feel. (Feel free to back those commits out if you prefer cosine.)

Tested with a Scout whose pins 9 and 11 are swapped, and with diodes added to the key matrix.